### PR TITLE
remove code to fix collapsed bug

### DIFF
--- a/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
+++ b/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
@@ -241,10 +241,7 @@
             [[self scrollView] setShowsVerticalScrollIndicator:YES];
 			return;
 		}
-        // Prevents the navbar from moving during the 'rubberband' scroll
-        if ([self contentoffset].y + self.scrollableView.frame.size.height > [self contentSize].height) {
-            return;
-        }
+
 		if (self.collapsed) {
             self.collapsed = NO;
         }


### PR DESCRIPTION
These codes will cause some bugs: When the first controller’s nag bar is collapsed, then I push the second controller, the nag bar will be a area of black at this time.
