### PR TITLE
Fallback to the UIAppearance value for barTintColor

### DIFF
--- a/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
+++ b/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
@@ -59,15 +59,18 @@
 	frame.origin = CGPointZero;
 	self.overlay = [[UIView alloc] initWithFrame:frame];
     
-    // Use tintColor instead of barTintColor on iOS < 7
-    if (IOS7_OR_LATER) {
-        if (!self.navigationController.navigationBar.barTintColor) {
-            NSLog(@"[%s]: %@", __PRETTY_FUNCTION__, @"[AMScrollingNavbarViewController] Warning: no bar tint color set");
-        }
-        [self.overlay setBackgroundColor:self.navigationController.navigationBar.barTintColor];
+  // Use tintColor instead of barTintColor on iOS < 7
+  if (IOS7_OR_LATER) {
+    if (self.navigationController.navigationBar.barTintColor) {
+      [self.overlay setBackgroundColor:self.navigationController.navigationBar.barTintColor];
+    } else if ([UINavigationBar appearance].barTintColor) {
+      [self.overlay setBackgroundColor:[UINavigationBar appearance].barTintColor];
     } else {
-        [self.overlay setBackgroundColor:self.navigationController.navigationBar.tintColor];
+      NSLog(@"[%s]: %@", __PRETTY_FUNCTION__, @"[AMScrollingNavbarViewController] Warning: no bar tint color set");
     }
+  } else {
+    [self.overlay setBackgroundColor:self.navigationController.navigationBar.tintColor];
+  }
 	
 	if ([self.navigationController.navigationBar isTranslucent]) {
 		NSLog(@"[%s]: %@", __PRETTY_FUNCTION__, @"[AMScrollingNavbarViewController] Warning: the navigation bar should not be translucent");


### PR DESCRIPTION
Without this change, the overlay fade effect does not work for applications that only specify barTintColor using the appearance proxy.

Currently, the barTintColor would have to be specified explicitly on the UINavigationBar instance referenced by self.navigationController.navigationBar. With the modifications I've made, the barTintColor will check for the UIAppearance value on UINavigationBar for the barTintColor before issuing the warning "no bar tint color set".
