### PR TITLE
Remove observer of particular notification only

### DIFF
--- a/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
+++ b/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
@@ -102,7 +102,7 @@
     self.overlay = nil;
     self.scrollableView = nil;
     self.panGesture = nil;
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 - (void)didBecomeActive:(id)sender


### PR DESCRIPTION
Hi there, can we remove the observer of `UIApplicationDidBecomeActiveNotification` only? Since when we call `[self stopFollowingScrollView]` we cannot receive all other notifications registered previously by our view controller.
