### PR TITLE
When navigation bar is not fully collapsed, there is no way to hide it.

### DIFF
--- a/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
+++ b/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
@@ -212,7 +212,9 @@
 - (void)showNavBarAnimated:(BOOL)animated
 {
     if (self.scrollableView != nil) {
-        if (self.collapsed) {
+        BOOL isTracking = self.panGesture.state == UIGestureRecognizerStateBegan || self.panGesture.state == UIGestureRecognizerStateChanged;
+        if (self.collapsed || isTracking) {
+            self.panGesture.enabled = NO;
             if (!self.scrollableViewConstraint) {
                 // Frame version
                 CGRect rect = [self scrollView].frame;
@@ -225,6 +227,8 @@
                 self.delayDistance = -self.navbarHeight;
                 [self scrollWithDelta:-self.navbarHeight];
                 [self.view setNeedsLayout];
+            } completion:^(BOOL finished) {
+                self.panGesture.enabled = YES;
             }];
         } else {
             [self updateNavbarAlpha:self.navbarHeight];

--- a/ScrollingNavbarDemo/ScrollingNavbarDemo.xcodeproj/project.pbxproj
+++ b/ScrollingNavbarDemo/ScrollingNavbarDemo.xcodeproj/project.pbxproj
@@ -106,7 +106,9 @@
 				652B446E182D376600D01F5C /* Frameworks */,
 				652B446D182D376600D01F5C /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		652B446D182D376600D01F5C /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
When controller disappeared I want to show navigation bar. I have button that pushes another controller and can be clicked simultaneously with pan gesture. So if navigation bar is not fully collapsed and I click on this button, showNavBar has no effect
