### PR TITLE
Fixed topLayoutGuide constraint reversal causing navBar hiding to be reversed

### DIFF
--- a/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
+++ b/AMScrollingNavbar/UIViewController+ScrollingNavbar.m
@@ -489,7 +489,14 @@
     frame.origin.y = frameNav.origin.y + frameNav.size.height;
     
     if (self.scrollableViewConstraint) {
-        self.scrollableViewConstraint.constant = -1 * ([self navbarHeight] - frame.origin.y);
+        // properly handle constraint commutativity
+        // (when programmatically constraining the topLayoutGuide, it may be either the first or second view in the relation)
+        CGFloat directionMultiplier = -1;
+        if ([self.scrollableViewConstraint.firstItem conformsToProtocol:@protocol(UILayoutSupport)]) {
+            directionMultiplier = 1;
+        }
+
+        self.scrollableViewConstraint.constant = directionMultiplier * ([self navbarHeight] - frame.origin.y);
     } else {
         frame.size.height = [UIScreen mainScreen].bounds.size.height - frame.origin.y;
         if (self.useSuperview) {


### PR DESCRIPTION
When programmatically affixing the `topLayoutGuide` to the top of the view, the constraint can be defined either with the topLayoutGuide as the `firstItem` or `secondItem` in the relationship. Both are correct, but the constraint's `constant` must be flipped accordingly, as neither order should be assumed by the library.