### PR TITLE
Set iOS deployment target to 8.0 (was 8.4 by default)

### DIFF
--- a/AMScrollingNavbar.xcodeproj/project.pbxproj
+++ b/AMScrollingNavbar.xcodeproj/project.pbxproj
@@ -262,6 +262,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AMScrollingNavbar/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -277,6 +278,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = AMScrollingNavbar/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Source/ScrollingNavbar.swift
+++ b/Source/ScrollingNavbar.swift
@@ -316,7 +316,10 @@ public class ScrollingNavigationController: UINavigationController, UIGestureRec
     }
 
     func deltaLimit() -> CGFloat {
-        if UI_USER_INTERFACE_IDIOM() == .Pad || UIScreen.mainScreen().scale == 3 {
+        let isAiPad = UIDevice().userInterfaceIdiom == .Pad
+        let isAiPhone6Plus = UIScreen.mainScreen().scale == 3
+
+        if isAiPad || isAiPhone6Plus {
             return portraitNavbar() - statusBar()
         } else {
             return (UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication().statusBarOrientation) ?


### PR DESCRIPTION
Before this fix, when using Carthage and importing this framework into a target supports iOS version lower than 8.4 will get following error

```
Module file's minimum deployment target is ios8.4 v8.4: .../Carthage/Build/iOS/AMScrollingNavbar.framework/Modules/AMScrollingNavbar.swiftmodule/x86_64.swiftmodule
```

Thank you for updating the project to Swift. :+1: 