### PR TITLE
Fix `scrollEnabled` implementation

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -387,6 +387,13 @@ public class ScrollingNavigationController: UINavigationController, UIGestureRec
     UIGestureRecognizerDelegate function. Enables the scrolling of both the content and the navigation bar
     */
     public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
+    }
+
+    /**
+     UIGestureRecognizerDelegate function. Only scrolls the navigation bar with the content when scrollingEnabled is true
+     */
+    public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldReceiveTouch touch: UITouch) -> Bool {
         return scrollingEnabled
     }
 

--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -39,7 +39,7 @@ public class ScrollingNavigationController: UINavigationController, UIGestureRec
     }
 
     /**
-    Determines wether the navbar should scroll when the content inside the scrollview fits
+    Determines whether the navbar should scroll when the content inside the scrollview fits
     the view's size. Defaults to `false`
     */
     public var shouldScrollWhenContentFits = false
@@ -384,7 +384,7 @@ public class ScrollingNavigationController: UINavigationController, UIGestureRec
     // MARK: - UIGestureRecognizerDelegate
 
     /** 
-    UIGestureRecognizerDelegate funcion. Enables the scrolling of both the content and the navigation bar
+    UIGestureRecognizerDelegate function. Enables the scrolling of both the content and the navigation bar
     */
     public func gestureRecognizer(gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWithGestureRecognizer otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return scrollingEnabled


### PR DESCRIPTION
This commit: https://github.com/andreamazz/AMScrollingNavbar/commit/ceffb9dca7acdccc1058c0e669dc747dec080e61 wasn't fixing the issue for me.  Instead of preventing this gesture recognizer from recognizing touches simultaneously with other GRs, I think we should block touch events entirely when `scrollingEnabled` is `false`.