### PR TITLE
Expose gestureRecognizer property and handle failover of gesture

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -67,9 +67,9 @@ public class ScrollingNavigationController: UINavigationController, UIGestureRec
     */
     public weak var scrollingNavbarDelegate: ScrollingNavigationControllerDelegate?
 
+    public private(set) var gestureRecognizer: UIPanGestureRecognizer?
     var delayDistance: CGFloat = 0
     var maxDelay: CGFloat = 0
-    var gestureRecognizer: UIPanGestureRecognizer?
     var scrollableView: UIView?
     var lastContentOffset = CGFloat(0.0)
 
@@ -172,17 +172,19 @@ public class ScrollingNavigationController: UINavigationController, UIGestureRec
     // MARK: - Gesture recognizer
 
     func handlePan(gesture: UIPanGestureRecognizer) {
-        if let superview = scrollableView?.superview {
-            let translation = gesture.translationInView(superview)
-            let delta = lastContentOffset - translation.y
-            lastContentOffset = translation.y
-
-            if shouldScrollWithDelta(delta) {
-                scrollWithDelta(delta)
+        if gesture.state != .Failed {
+            if let superview = scrollableView?.superview {
+                let translation = gesture.translationInView(superview)
+                let delta = lastContentOffset - translation.y
+                lastContentOffset = translation.y
+                
+                if shouldScrollWithDelta(delta) {
+                    scrollWithDelta(delta)
+                }
             }
         }
 
-        if gesture.state == .Ended || gesture.state == .Cancelled {
+        if gesture.state == .Ended || gesture.state == .Cancelled || gesture.state == .Failed {
             checkForPartialScroll()
             lastContentOffset = 0
         }


### PR DESCRIPTION
In my case i have horizontal UICollectionView, which cells need to requireGestureRecognizerToFail of navigationController gesture, so i needed to expose gestureRecognizer property and handle Failure state. This Fix #193 which i opened.