### PR TITLE
Give the option to not showNavBar

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -172,8 +172,10 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   /**
    Stop observing the view and reset the navigation bar
    */
-  public func stopFollowingScrollView() {
-    showNavbar(animated: false)
+  public func stopFollowingScrollView(show: Bool = true) {
+    if show {
+      showNavbar(animated: false)
+    }
     if let gesture = gestureRecognizer {
       scrollableView?.removeGestureRecognizer(gesture)
     }


### PR DESCRIPTION
Give the option to not showNavBar (let it in the current state) when we stopFollowingScrollView (temporarily in general, before call follow once again)