### PR TITLE
Include contentInset when calculating scroll view's contentSize

### DIFF
--- a/Demo/ScrollingNavbarDemo/ViewControllers/TableViewController.swift
+++ b/Demo/ScrollingNavbarDemo/ViewControllers/TableViewController.swift
@@ -18,7 +18,7 @@ class TableViewController: ScrollingNavigationViewController, UITableViewDelegat
     super.viewDidLoad()
 
     title = "TableView"
-    tableView.contentInset = UIEdgeInsets(top: 44, left: 0, bottom: 0, right: 0)
+    tableView.contentInset = UIEdgeInsets(top: 44, left: 0, bottom: 100, right: 0)
     toolbar.barTintColor = UIColor(red:0.91, green:0.3, blue:0.24, alpha:1)
     toolbar.tintColor = .white
     navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add, target: nil, action: nil)

--- a/Source/ScrollingNavbar+Sizes.swift
+++ b/Source/ScrollingNavbar+Sizes.swift
@@ -43,7 +43,12 @@ extension ScrollingNavigationController {
   }
 
   var contentSize: CGSize {
-    return scrollView()?.contentSize ?? CGSize.zero
+    guard let scrollView = scrollView() else {
+      return CGSize.zero
+    }
+
+    let verticalInset = scrollView.contentInset.top + scrollView.contentInset.bottom
+    return CGSize(width: scrollView.contentSize.width, height: scrollView.contentSize.height + verticalInset)
   }
 
   var deltaLimit: CGFloat {


### PR DESCRIPTION
This PR addresses https://github.com/andreamazz/AMScrollingNavbar/issues/271. The navigation bar will now show up immediately when the user is scrolling from the bottom of the scroll view with a significant `contentInset` set. I've also updated the demo app to demonstrate a table view with extra bottom inset to trigger the correct behaviour.