### PR TITLE
Fix for extended status bar issue

### DIFF
--- a/Source/ScrollingNavbar+Sizes.swift
+++ b/Source/ScrollingNavbar+Sizes.swift
@@ -17,7 +17,12 @@ extension ScrollingNavigationController {
   }
 
   var statusBarHeight: CGFloat {
-    return UIApplication.shared.statusBarFrame.size.height
+    return UIApplication.shared.statusBarFrame.size.height - extendedStatusBarDifference
+  }
+
+  // Extended status call changes the bounds of the presented view
+  var extendedStatusBarDifference: CGFloat {
+    return abs(view.bounds.height - UIScreen.main.bounds.height)
   }
 
   var tabBarOffset: CGFloat {


### PR DESCRIPTION
This is for https://github.com/andreamazz/AMScrollingNavbar/issues/273

I've noticed inconsistencies between bounds of the screen and presented view controller when an extended status bar is visible and I made a simple adjustment . I've checked this in iPhone X simulator and it looks like it is not an issue on that device. Below a quick screen grab of the fix:

![b](https://user-images.githubusercontent.com/913452/31495371-4a208bea-af4f-11e7-9bc4-b113b477279a.gif)
