### PR TITLE
Update ScrollingNavigationController.swift

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -30,6 +30,7 @@ import UIKit
  A custom `UINavigationController` that enables the scrolling of the navigation bar alongside the
  scrolling of an observed content view
  */
+@objcMembers
 open class ScrollingNavigationController: UINavigationController, UIGestureRecognizerDelegate {
 
   /**


### PR DESCRIPTION
Support Objective-c with Swift 4

At the moment your project is not supporting objective c with swift 4 that is really bad for my project. For more information take a look of this: http://evgenii.com/blog/disabling-swift3-objc-inference-in-xcode9/

Functions like this are not working:
[((ScrollingNavigationController *)self.navigationController) followScrollView: tableView delay:(0.0) scrollSpeedFactor:1.0 followers:followers];

Please accept the pull request to enable objective c with swift4. thanks