### PR TITLE
Added support for custom UIScreen height

### DIFF
--- a/Source/ScrollingNavbar+Sizes.swift
+++ b/Source/ScrollingNavbar+Sizes.swift
@@ -22,7 +22,7 @@ extension ScrollingNavigationController {
 
   // Extended status call changes the bounds of the presented view
   var extendedStatusBarDifference: CGFloat {
-    return abs(view.bounds.height - UIScreen.main.bounds.height)
+    return abs(view.bounds.height - (UIApplication.shared.delegate?.window??.frame.size.height ?? UIScreen.main.bounds.height))
   }
 
   var tabBarOffset: CGFloat {


### PR DESCRIPTION
We have a "No internet" view that shows up in the bottom of our app which is added to the application window. When it is showing, the navigation bar does not expand fully due to the computation of extendedStatusBarDifference.
This fixes the issue