### PR TITLE
Fix #302: View background shows through during animation

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -532,7 +532,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
       let navBarY = navigationBar.frame.origin.y + navigationBar.frame.size.height
       frame = topViewController.view.frame
       frame.origin = CGPoint(x: frame.origin.x, y: navBarY)
-      frame.size = CGSize(width: frame.size.width, height: view.frame.size.height - (navBarY) - tabBarOffset)
+      frame.size = CGSize(width: frame.size.width, height: view.frame.size.height - navBarY - delta - tabBarOffset)
       topViewController.view.frame = frame
     }
   }


### PR DESCRIPTION
As reported in #302, the host viewcontroller background shows through
in the bottom of the view during showNavBar animation in TableView,
WebView and CollectionView examples in the Demo app. This commit
addresses the issue by taking the delta into account when calculating
the frame size changes in updateSizing.

I have tested this fix with the changes to demo app as implemented in @Alexookah 's fork at https://github.com/Alexookah/AMScrollingNavbar and the background color viewing through is not reproducing with this fix. 