### PR TITLE
Removed recursive subview hiding.

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -617,35 +617,6 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
       }
     }
 
-    // Hide all possible button items and navigation items
-    func shouldHideView(_ view: UIView) -> Bool {
-      let className = view.classForCoder.description().replacingOccurrences(of: "_", with: "")
-      var viewNames = ["UINavigationButton", "UINavigationItemView", "UIImageView", "UISegmentedControl"]
-      if #available(iOS 11.0, *) {
-        viewNames.append(navigationBar.prefersLargeTitles ? "UINavigationBarLargeTitleView" : "UINavigationBarContentView")
-      } else {
-        viewNames.append("UINavigationBarContentView")
-      }
-      return viewNames.contains(className)
-    }
-
-    func setAlphaOfSubviews(view: UIView, alpha: CGFloat) {
-      if let label = view as? UILabel {
-        label.textColor = label.textColor.withAlphaComponent(alpha)
-      } else if let label = view as? UITextField {
-        label.textColor = label.textColor?.withAlphaComponent(alpha)
-      } else if view.classForCoder == NSClassFromString("_UINavigationBarContentView") {
-        // do nothing
-      } else {
-        view.alpha = alpha
-      }
-      view.subviews.forEach { setAlphaOfSubviews(view: $0, alpha: alpha) }
-    }
-
-    navigationBar.subviews
-      .filter(shouldHideView)
-      .forEach { setAlphaOfSubviews(view: $0, alpha: alpha) }
-
     // Hide the left items
     navigationItem.leftBarButtonItem?.customView?.alpha = alpha
     navigationItem.leftBarButtonItems?.forEach { $0.customView?.alpha = alpha }


### PR DESCRIPTION
Fix for #367.

**Motivation**

After investigating this and testing on iOS's 8-12 I could not observe that recursive subview actually does anything(except causing flickering on iOS 11 and 12 :). 

Bar button items(including those with custom views) are handled by these:
```swift
    navigationItem.leftBarButtonItem?.tintColor = navigationItem.leftBarButtonItem?.tintColor?.withAlphaComponent(alpha)
    navigationItem.rightBarButtonItem?.tintColor = navigationItem.rightBarButtonItem?.tintColor?.withAlphaComponent(alpha)
    navigationItem.leftBarButtonItems?.forEach { $0.tintColor = $0.tintColor?.withAlphaComponent(alpha) }
    navigationItem.rightBarButtonItems?.forEach { $0.tintColor = $0.tintColor?.withAlphaComponent(alpha) }
...
    // Hide the left items
    navigationItem.leftBarButtonItem?.customView?.alpha = alpha
    navigationItem.leftBarButtonItems?.forEach { $0.customView?.alpha = alpha }

    // Hide the right items
    navigationItem.rightBarButtonItem?.customView?.alpha = alpha
    navigationItem.rightBarButtonItems?.forEach { $0.customView?.alpha = alpha }
```

Title and title view handled here:
```swift
    navigationItem.titleView?.alpha = alpha
   ...
    if let titleColor = navigationBar.titleTextAttributes?[NSAttributedString.Key.foregroundColor] as? UIColor {
      navigationBar.titleTextAttributes?[NSAttributedString.Key.foregroundColor] = titleColor.withAlphaComponent(alpha)
    } else {
      let blackAlpha = UIColor.black.withAlphaComponent(alpha)
      if navigationBar.titleTextAttributes == nil {
        navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: blackAlpha]
      } else {
        navigationBar.titleTextAttributes?[NSAttributedString.Key.foregroundColor] = blackAlpha
      }
    }
```

Any other "tintable" stuff handled here
```swift
    navigationBar.tintColor = navigationBar.tintColor.withAlphaComponent(alpha)
```

It seems that all cases are covered already without the need to traverse navigation bar view hierarchy updating alpha for each of them(which also has it's problems).

**Issue with recursive alpha**

As the documentation for [`UIView.alpha`](https://developer.apple.com/documentation/uikit/uiview/1622417-alpha) states 

> transparency imparted by that alpha value affects all of the view's contents, including its subviews

Which results in alpha value of a view being multiplied by alpha of its superview(and superview of superview and so on).
In this illustration you can see what I'm trying to describe:
<img width="301" alt="Screenshot 2019-07-31 at 14 44 47" src="https://user-images.githubusercontent.com/1478430/62209265-d4095a00-b3a1-11e9-8b7c-41ecb11cc106.png">

The first square consists of a white view with alpha `0.5` and a black subview with alpha `0.5`. Square two and three are just for comparison - the first one is a black view with alpha 0.25, second one - 0.5.
This shows that recursively applying alpha produces result different from desired - in an attempt to set everything to `0.5` - the result ended up looking as if it has alpha of value `0.25`. And this is in controlled environment - view hierarchy depth is limited to 2 in this example, this should be more pronounced when nesting is deeper, the alpha of the deepest view should be desired_alpha^depth.

Here's playground with this setup: 
[RecursiveAlphaPlayground.playground.zip](https://github.com/andreamazz/AMScrollingNavbar/files/3451664/RecursiveAlphaPlayground.playground.zip)

