### PR TITLE
Remove the deprecated API usage problem

### DIFF
--- a/AMScrollingNavbar.podspec
+++ b/AMScrollingNavbar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "AMScrollingNavbar"
-  s.version       = "5.3.1"
+  s.version       = "5.4.0"
   s.summary       = "A custom UINavigationController that enables the scrolling of the navigation bar alongside the scrolling of an observed content view"
   s.description   = <<-DESC
                      A custom UINavigationController that enables the scrolling of the

--- a/AMScrollingNavbar.podspec
+++ b/AMScrollingNavbar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "AMScrollingNavbar"
-  s.version       = "5.3.0"
+  s.version       = "5.3.1"
   s.summary       = "A custom UINavigationController that enables the scrolling of the navigation bar alongside the scrolling of an observed content view"
   s.description   = <<-DESC
                      A custom UINavigationController that enables the scrolling of the

--- a/Source/ScrollingNavbar+Sizes.swift
+++ b/Source/ScrollingNavbar+Sizes.swift
@@ -45,9 +45,7 @@ extension ScrollingNavigationController {
   }
   
   func scrollView() -> UIScrollView? {
-    if let webView = self.scrollableView as? UIWebView {
-      return webView.scrollView
-    } else if let wkWebView = self.scrollableView as? WKWebView {
+    if let wkWebView = self.scrollableView as? WKWebView {
       return wkWebView.scrollView
     } else {
       return scrollableView as? UIScrollView


### PR DESCRIPTION
Apple have started to clamp down on the use of deprecated APIs. In AMScrollingNavBar/ScrollingNavbar+Sizes.swift there is reference to this deprecated control.

This fork and pull request fixes the issue.

(ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs)