### PR TITLE
Bug fix: updateNavbarAlpha() unnecessarily persisting dimmed tint

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -279,7 +279,6 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     guard let _ = self.scrollableView, let visibleViewController = self.visibleViewController else { return }
 
     guard state == .collapsed else {
-      updateNavbarAlpha()
       return
     }
 


### PR DESCRIPTION
Context: under most circumstances, UIKit will automatically dim the navigation bar when the keyboard pops up (unless [tintAdjustmentMode](https://developer.apple.com/documentation/uikit/uiview/1622555-tintadjustmentmode) is set to `normal`)

If `ScrollingNavigationController`'s `updateNavbarAlpha()` is called while the keyboard is up, the line `navigationBar.tintColor = navigationBar.tintColor.withAlphaComponent(alpha)` will cause the dimmed tint to be permanent.

The events `windowDidBecomeVisible` and `didRotate` will typically be fired when the keyboard pops up. For both events `showNavbar()` will be invoked, which in turn will call `updateNavbarAlpha()` and exit immediately. This call to `updateNavbarAlpha()` can be harmful as described above, and I can't see a scenario where it would be helpful so I removed it completely.
