### PR TITLE
added expandOnVisible

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -112,6 +112,11 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   open var expandOnActive = true
   
   /**
+   Determines if the navbar should expand once the application becomes visible after entering background
+   Defaults to `true`
+   */
+  open var expandOnVisible = true
+  /**
    Determines if the navbar scrolling is enabled.
    Defaults to `true`
    */
@@ -356,7 +361,13 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   // MARK: - Fullscreen handling
   
   func windowDidBecomeVisible(_ notification: Notification) {
-    showNavbar()
+    if expandOnVisible {
+      showNavbar(animated: false)
+    } else {
+      if previousState == .collapsed {
+        hideNavbar(animated: false)
+      }
+    }
   }
   
   // MARK: - Rotation handler

--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -362,7 +362,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   
   func windowDidBecomeVisible(_ notification: Notification) {
     if expandOnVisible {
-      showNavbar(animated: false)
+      showNavbar()
     } else {
       if previousState == .collapsed {
         hideNavbar(animated: false)


### PR DESCRIPTION
I had an issue where i was showing a full screen image and when closed the navbar would automatically expand because of the notification DidBecomeVisible.

I see that you have a boolean value DidBecomActive and i thought it might be useful for someone else to have control and disable DidBecomeActive not to show the navbar from default.

hope this gets merged :)

Thanks for your awesome library