### PR TITLE
Sticky Followers Handling

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -550,7 +550,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
             
             switch index {
             case 0:
-              follower.view?.transform = CGAffineTransform(translationX: 0, y: min(y, 0))
+              follower.view?.transform = CGAffineTransform(translationX: 0, y: max(y, 0))
             default:
               let previousFollowers = self.followers[0..<index]
               // Do not go less than the first non sticky follower Height

--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -547,7 +547,6 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
         case .scrollUp:
           let y = -(statusBarHeight - navigationBar.frame.origin.y)
           if follower.isSticky {
-            
             switch index {
             case 0:
               follower.view?.transform = CGAffineTransform(translationX: 0, y: max(y, 0))
@@ -555,8 +554,8 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
               let previousFollowers = self.followers[0..<index]
               // Do not go less than the first non sticky follower Height
               let previousStickyFollowersHeight = previousFollowers.filter{ !$0.isSticky }.compactMap { $0.view?.frame.height }.reduce(0, +)
-              let sticky_y = max(y, -previousStickyFollowersHeight)
-              follower.view?.transform = CGAffineTransform(translationX: 0, y: sticky_y)
+              let stickyY = max(y, -previousStickyFollowersHeight)
+              follower.view?.transform = CGAffineTransform(translationX: 0, y: stickyY)
             }
           } else {
             follower.view?.transform = CGAffineTransform(translationX: 0, y: y)


### PR DESCRIPTION
Added the sticky followers request
https://github.com/andreamazz/AMScrollingNavbar/issues/291

See in video how it works
https://streamable.com/3dhtj

Made a branch with the example  as shown from the video:
https://github.com/Alexookah/AMScrollingNavbar/tree/sticky-followers
(simply do pod install to get my repo's master branch code)

This is tested using:
UINavigationBar.appearance().isTranslucent = false

Currently its pretty simple handling. Each follower is checking the previous followers height.
This could be changed into some more customizable setup with some followers to be fully hidden or not.

I think this might be useful for some people like i needed this :)

Hope my implementation is good enough for merge. 
Feel free to tell me if something needs to be changed.
