### PR TITLE
Bug fixed. followScrollView function not working.

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -203,7 +203,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
    - parameter followers: An array of `NavigationBarFollower`s that will follow the navbar. The wrapper holds the direction that the view will follow
    */
   open func followScrollView(_ scrollableView: UIView, delay: Double = 0, scrollSpeedFactor: Double = 1, collapseDirection: NavigationBarCollapseDirection = .scrollDown, additionalOffset: CGFloat = 0, followers: [NavigationBarFollower] = []) {
-    guard self.scrollableView == nil else {
+    if self.scrollableView != nil {
       // Restore previous state. UIKit restores the navbar to its full height on view changes (e.g. during a modal presentation), so we need to restore the status once UIKit is done
       switch previousState {
       case .collapsed:
@@ -212,7 +212,6 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
         showNavbar(animated: false)
       default: break
       }
-      return
     }
     self.scrollableView = scrollableView
     


### PR DESCRIPTION
Hello. 

I used followScrollView function in my project. but followScrollView function have not been working. so followScrollView function fixed.

Because This logic can not passed guard block when reset a scrollableView.

I think, If self.scrollableView is not nil, play switch. And  reset the new scrollableView always.

How about my propose?