### PR TITLE
Change shouldScrollWithDelta to take in account the followersHeight

### DIFF
--- a/Source/ScrollingNavbar+Sizes.swift
+++ b/Source/ScrollingNavbar+Sizes.swift
@@ -68,4 +68,8 @@ extension ScrollingNavigationController {
   var navbarFullHeight: CGFloat {
     return navbarHeight - statusBarHeight + additionalOffset
   }
+  
+  var followersHeight: CGFloat {
+      return self.followers.filter { $0.direction == .scrollUp }.compactMap { $0.view?.frame.height }.reduce(0, +)
+  }
 }

--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -294,12 +294,11 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     
     let completion = {
       if scrollToTop {
-        var followersHeight = self.followers.filter { $0.direction == .scrollUp }.compactMap { $0.view?.frame.height }.reduce(0, +)
-        followersHeight += self.additionalScrollToTopOffset
+        let followersFinalHeight = self.followersHeight + self.additionalScrollToTopOffset
         if self.isTopViewControllerExtendedUnderNavigationBar {
-          self.scrollView()?.setContentOffset(CGPoint(x: 0, y: -self.fullNavbarHeight - followersHeight), animated: true)
+          self.scrollView()?.setContentOffset(CGPoint(x: 0, y: -self.fullNavbarHeight - followersFinalHeight), animated: true)
         } else {
-          self.scrollView()?.setContentOffset(CGPoint(x: 0, y: -followersHeight), animated: true)
+          self.scrollView()?.setContentOffset(CGPoint(x: 0, y: -followersFinalHeight), animated: true)
         }
       }
     }
@@ -434,7 +433,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   private func shouldScrollWithDelta(_ delta: CGFloat) -> Bool {
     let scrollDelta = delta
     // Do not hide too early
-    if contentOffset.y < ((isTopViewControllerExtendedUnderNavigationBar ? -fullNavbarHeight : 0) + scrollDelta) {
+    if contentOffset.y < ((isTopViewControllerExtendedUnderNavigationBar ? -fullNavbarHeight : followersHeight) + scrollDelta) {
       return false
     }
     // Check for rubberbanding


### PR DESCRIPTION
I added followersHeight in ScrollingNavbar+Sizes to use it anywhere needed.
Fixed the issue that it would not scroll.
The case was when the UINavigationBar.appearance().isTranslucent = false was not working correctly when the navbar was collapsed.

this fixes issue https://github.com/andreamazz/AMScrollingNavbar/issues/379