### PR TITLE
issue 379 fix

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -433,7 +433,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   private func shouldScrollWithDelta(_ delta: CGFloat) -> Bool {
     let scrollDelta = delta
     // Do not hide too early
-    if contentOffset.y < ((isTopViewControllerExtendedUnderNavigationBar ? -fullNavbarHeight : followersHeight) + scrollDelta) {
+    if contentOffset.y < ((isTopViewControllerExtendedUnderNavigationBar ? -fullNavbarHeight : -followersHeight) + scrollDelta) {
       return false
     }
     // Check for rubberbanding
@@ -518,6 +518,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   /// Adjust the top inset (useful when a table view has floating headers, see issue #219
   private func updateContentInset(_ delta: CGFloat) {
     if self.shouldUpdateContentInset, let contentInset = scrollView()?.contentInset, let scrollInset = scrollView()?.scrollIndicatorInsets {
+      
       scrollView()?.contentInset = UIEdgeInsets(top: contentInset.top - delta, left: contentInset.left, bottom: contentInset.bottom, right: contentInset.right)
       scrollView()?.scrollIndicatorInsets = UIEdgeInsets(top: scrollInset.top - delta, left: scrollInset.left, bottom: scrollInset.bottom, right: scrollInset.right)
       scrollingNavbarDelegate?.scrollingNavigationController?(self,


### PR DESCRIPTION
The previous fix was wrong.
This is the correct value for the case when there is no searchController in the navigationBar.

This fix  doesnt handle the case for .isTranslucent = false with searchController in the navigationBar.
I couldnt handle it because the checkSearchController(delta) was not really working correct to take that in account as well.

I also think updateContentInset are also wrong when the searchController exists for .isTranslucent = false