### PR TITLE
showNavbar() should set opacity to 1 when state is expanded

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -293,6 +293,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     guard let _ = self.scrollableView, let visibleViewController = self.visibleViewController else { return }
     
     guard state == .collapsed else {
+      self.updateNavbarAlpha()
       return
     }
         


### PR DESCRIPTION
This fixes a bug where the Nav Bar expands after being collapsed, but looks empty under some circumstances.

This happens when the the scroll view's `UIViewController` presents a new `UINavigationController` modally (`.overFullScreen`), and after the Nav Bar was previously collapsed by scrolling up. At this point, `windowDidBecomeVisible()` is called, which in turns calls `showNavbar()`.

When `showNavbar()` executes at this point, the value of the state is `.expanded` so the method call simply exits without doing anything.  The issue is that the alpha value was set to zero when the Nav Bar was previously collapsed, and it is still zero at this stage so the Nav Bar appears empty.

This fixes the immediate issue at hand, and I am pretty confident that the change doesn't cause any harm.
This said I suspect there may be a better way to address this? In particular when showNavbar() executes, the state ***should*** be `.collapsed`, not `.expanded` - I suspect this has to do with the way the modal UINavigationController interacts with the Nav Bar (?!? This is where I have more questions than answers) 