### PR TITLE
Bug: UIKit-applied dimming made permanent by call to showNavbar()

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -387,6 +387,16 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   
   func windowDidBecomeVisible(_ notification: Notification) {
     if expandOnVisible {
+      let senderTypeStr = "\(type(of: notification.object as AnyObject))"
+      // Ugh...had to hardcode the class name. Is there a better way ?
+      guard senderTypeStr != "UIRemoteKeyboardWindow" else {
+        // We are dealing with UIAlert or a Keyboard popping up: UIKit will automatically dim the content of the nav bar.
+        // We should not call showNavBar(), because
+        // 1. It serves no purpose here
+        // 2. If were to call, the dimming applied by UIKit would be made permanent via showNavBar()/updateNavbarAlpha()
+        // .....navigationBar.tintColor = navigationBar.tintColor.withAlphaComponent(alpha)
+        return
+      }
       showNavbar()
     } else {
       if previousState == .collapsed {


### PR DESCRIPTION
When the keyboard pops up (or a UIAlert), the temporary UIKit-applied dimming is made permanent by `windowDidBecomeVisible() > showNavbar() > updateNavbarAlpha()`

At `ScrollingNavigationControllerDelegate`line 653 `updateNavbarAlpha()`
`navigationBar.tintColor = navigationBar.tintColor.withAlphaComponent(alpha)` 

....the proposed fix skips the call to showNavbar() when the right conditions are detected