### PR TITLE
UIKit-applied dimming bug fixed by duplicating tintColor value

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ controller.followScrollView(view, delay: 0, scrollSpeedFactor: 2)
 
 Check out the sample project for more details.
 
+## Changing UINavigationBar.tintColor
+AMScrollingNavBar maintains its own copy of the UINavigationBar's `tintColor` property. You need to notify the AMScrollingNavBar of a tint change by calling `navBarTintUpdated()`:
+
+```swift
+navigationBar.tintColor = UIColor.red
+controller.navBarTintUpdated()
+```
+
+Check out the sample project for more details.
+
 # Author
 [Andrea Mazzini](https://twitter.com/theandreamazz). I'm available for freelance work, feel free to contact me.
 

--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -179,6 +179,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
   open fileprivate(set) var gestureRecognizer: UIPanGestureRecognizer?
   fileprivate var sourceTabBar: TabBarMock?
   fileprivate var previousOrientation: UIDeviceOrientation = UIDevice.current.orientation
+  fileprivate var savedNavBarTintColor: UIColor?
   var delayDistance: CGFloat = 0
   var maxDelay: CGFloat = 0
   var scrollableView: UIView?
@@ -208,6 +209,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
    - parameter followers: An array of `NavigationBarFollower`s that will follow the navbar. The wrapper holds the direction that the view will follow
    */
   open func followScrollView(_ scrollableView: UIView, delay: Double = 0, scrollSpeedFactor: Double = 1, collapseDirection: NavigationBarCollapseDirection = .scrollDown, additionalOffset: CGFloat = 0, followers: [NavigationBarFollower] = []) {
+    savedNavBarTintColor = navigationBar.tintColor
     guard self.scrollableView == nil else {
       // Restore previous state. UIKit restores the navbar to its full height on view changes (e.g. during a modal presentation), so we need to restore the status once UIKit is done
       switch previousState {
@@ -352,6 +354,13 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     let center = NotificationCenter.default
     center.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
     center.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
+  }
+  
+  /**
+  The app needs to call navBarTintUpdated() after setting a new value for navigationBar.tintColor (or the new tintColor value will not take effect)
+  */
+  open func navBarTintUpdated() {
+    savedNavBarTintColor = navigationBar.tintColor
   }
   
   // MARK: - Gesture recognizer
@@ -640,7 +649,7 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     
     // Hide all the possible titles
     navigationItem.titleView?.alpha = alpha
-    navigationBar.tintColor = navigationBar.tintColor.withAlphaComponent(alpha)
+    navigationBar.tintColor = savedNavBarTintColor?.withAlphaComponent(alpha)
     navigationItem.leftBarButtonItem?.tintColor = navigationItem.leftBarButtonItem?.tintColor?.withAlphaComponent(alpha)
     navigationItem.rightBarButtonItem?.tintColor = navigationItem.rightBarButtonItem?.tintColor?.withAlphaComponent(alpha)
     navigationItem.leftBarButtonItems?.forEach { $0.tintColor = $0.tintColor?.withAlphaComponent(alpha) }


### PR DESCRIPTION
Updated so `ScrollingNavigationController` now maintains its own copy of the UINavigationBar's `tintColor` property - thus avoiding situations where UIKit-applied dimming is accidentally made permanent through a combination of UIAlert + device rotation for example.

More context at #391 