### PR TITLE
The back button text color changed from transparent to black.

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -679,9 +679,9 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     
     func setAlphaOfSubviews(view: UIView, alpha: CGFloat) {
       if let label = view as? UILabel {
-        label.textColor = label.textColor.withAlphaComponent(alpha)
+        label.textColor = label.textColor == .clear ? .clear : label.textColor.withAlphaComponent(alpha)
       } else if let label = view as? UITextField {
-        label.textColor = label.textColor?.withAlphaComponent(alpha)
+        label.textColor = label.textColor == .clear ? .clear : label.textColor?.withAlphaComponent(alpha)
       } else if view.classForCoder == NSClassFromString("_UINavigationBarContentView") {
         // do nothing
       } else {


### PR DESCRIPTION
Hi, @andreamazz 
Thank you for the cool library.

After hiding the navigation bar, the back button text color changed from transparent to black.
And I solved the problem.

|Before|After|
|:--:|:--:|
|![before](https://user-images.githubusercontent.com/25205138/87564617-92c9a180-c6fb-11ea-985c-3e6269eddef3.gif)|![after](https://user-images.githubusercontent.com/25205138/87564646-9d843680-c6fb-11ea-894e-bd148982a332.gif)|

Updating the navigation appearance in sample app is the following.

```
extension UINavigationController {
    func setupCustomNavigation() {
        let clear = [NSAttributedString.Key.foregroundColor: UIColor.clear]

        if #available(iOS 13.0, *) {
            let barAppearance = UINavigationBarAppearance()

            // Hide back button title.
            let barButtonAppearance = UIBarButtonItemAppearance()
            barButtonAppearance.normal.titleTextAttributes = clear
            barButtonAppearance.highlighted.titleTextAttributes = clear
            barAppearance.backButtonAppearance = barButtonAppearance

            // Set NavigationBar background color.
            barAppearance.backgroundColor = .yellow

            self.navigationBar.standardAppearance = barAppearance
            self.navigationBar.isTranslucent = false
        }
        else {
            // Hide back button title.
            UIBarButtonItem
                .appearance(whenContainedInInstancesOf: [UINavigationBar.self])
                .setTitleTextAttributes(clear, for: .normal)

            UIBarButtonItem
                .appearance(whenContainedInInstancesOf: [UINavigationBar.self])
                .setTitleTextAttributes(clear, for: .highlighted)

            // Set NavigationBar background color.
            self.navigationBar.barTintColor = .yellow
            self.navigationBar.isTranslucent = false
        }
    }
}
```

Best regards,