### PR TITLE
Hotfix for IOS 13 NavigationBar appearance issues

### DIFF
--- a/Source/ScrollingNavigationController.swift
+++ b/Source/ScrollingNavigationController.swift
@@ -648,6 +648,19 @@ open class ScrollingNavigationController: UINavigationController, UIGestureRecog
     let alpha = 1 - percentage
     
     // Hide all the possible titles
+    if #available(iOS 13.0, *) {
+        if let color = navigationBar.scrollEdgeAppearance?.titleTextAttributes [NSAttributedString.Key.foregroundColor] as? UIColor {
+            navigationBar.scrollEdgeAppearance?.titleTextAttributes [NSAttributedString.Key.foregroundColor] = color.withAlphaComponent(alpha)
+        }
+        
+        if let color = navigationBar.standardAppearance.titleTextAttributes [NSAttributedString.Key.foregroundColor] as? UIColor {
+            navigationBar.standardAppearance.titleTextAttributes [NSAttributedString.Key.foregroundColor] = color.withAlphaComponent(alpha)
+        }
+        
+        if let color = navigationBar.compactAppearance?.titleTextAttributes [NSAttributedString.Key.foregroundColor] as? UIColor {
+            navigationBar.compactAppearance?.titleTextAttributes [NSAttributedString.Key.foregroundColor] = color.withAlphaComponent(alpha)
+        }
+    }
     navigationItem.titleView?.alpha = alpha
     navigationBar.tintColor = savedNavBarTintColor?.withAlphaComponent(alpha)
     navigationItem.leftBarButtonItem?.tintColor = navigationItem.leftBarButtonItem?.tintColor?.withAlphaComponent(alpha)


### PR DESCRIPTION
Fixed #398  by using IOS 13+ APIs to update titleTextAttributes across all possible NavigationBar appearance modes, rather than only in the defaultAppearance.

Could possible use refactoring in future revisions for conciseness. But for now, this fix quickly and properly addresses the issue for developers targetting 13+ and up, that use largeTitles or other new toolbar appearances introduced. 
